### PR TITLE
docs: update about Usage

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -36,13 +36,13 @@ yarn add md-editor-v3 @vavt/md-editor-extension
 </template>
 
 <script setup>
-import MdEditor from 'md-editor-v3';
+import { MdEditor, config } from 'md-editor-v3';
 // 引入公共库中的预览主题
 import '@vavt/md-editor-extension/dist/previewTheme/arknights.css';
 // 引入公共库中的语言配置
 import ZH_TW from '@vavt/md-editor-extension/dist/locale/zh-TW';
 
-MdEditor.config({
+config({
   editorConfig: {
     languageUserDefined: {
       'zh-TW': ZH_TW,
@@ -64,13 +64,13 @@ yarn add md-editor-rt @vavt/md-editor-extension
 
 ```jsx
 import React from 'react';
-import MdEditor from 'md-editor-rt';
+import { MdEditor, config } from 'md-editor-v3';
 // 引入公共库中的预览主题
 import '@vavt/md-editor-extension/dist/previewTheme/arknights.css';
 // 引入公共库中的语言配置
 import ZH_TW from '@vavt/md-editor-extension/dist/locale/zh-TW';
 
-MdEditor.config({
+config({
   editorConfig: {
     languageUserDefined: {
       'zh-TW': ZH_TW,

--- a/README-CN.md
+++ b/README-CN.md
@@ -64,7 +64,7 @@ yarn add md-editor-rt @vavt/md-editor-extension
 
 ```jsx
 import React from 'react';
-import { MdEditor, config } from 'md-editor-v3';
+import { MdEditor, config } from 'md-editor-rt';
 // 引入公共库中的预览主题
 import '@vavt/md-editor-extension/dist/previewTheme/arknights.css';
 // 引入公共库中的语言配置

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ yarn add md-editor-v3 @vavt/md-editor-extension
 </template>
 
 <script setup>
-import MdEditor from 'md-editor-v3';
+import { MdEditor, config } from 'md-editor-v3';
 // import theme css
 import '@vavt/md-editor-extension/dist/previewTheme/arknights.css';
 // import existing language
 import ZH_TW from '@vavt/md-editor-extension/dist/locale/zh-TW';
 
-MdEditor.config({
+config({
   editorConfig: {
     languageUserDefined: {
       'zh-TW': ZH_TW,
@@ -64,13 +64,13 @@ yarn add md-editor-rt @vavt/md-editor-extension
 
 ```jsx
 import React from 'react';
-import MdEditor from 'md-editor-rt';
+import { MdEditor, config } from 'md-editor-v3';
 // import existing theme
 import '@vavt/md-editor-extension/dist/previewTheme/arknights.css';
 // import existing language
 import ZH_TW from '@vavt/md-editor-extension/dist/locale/zh-TW';
 
-MdEditor.config({
+config({
   editorConfig: {
     languageUserDefined: {
       'zh-TW': ZH_TW,

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ yarn add md-editor-rt @vavt/md-editor-extension
 
 ```jsx
 import React from 'react';
-import { MdEditor, config } from 'md-editor-v3';
+import { MdEditor, config } from 'md-editor-rt';
 // import existing theme
 import '@vavt/md-editor-extension/dist/previewTheme/arknights.css';
 // import existing language


### PR DESCRIPTION
In v4.0.0 of md-editor-v3 and md-editor-rt, the import method of `MdEditor` and `config` has been changed, please refer to https://github.com/imzbf/md-editor-v3#-usage.
This PR has updated README.md about how to import `MdEditor` and `config`