### PR TITLE
docs: updated russian translation

### DIFF
--- a/packages/common/src/locale/ru.ts
+++ b/packages/common/src/locale/ru.ts
@@ -31,6 +31,7 @@ const RU: StaticTextDefaultValue = {
     pageFullscreen: 'на всю страницу',
     fullscreen: 'на весь экран',
     preview: 'превью',
+    previewOnly: 'только превью',
     htmlPreview: 'превью html',
     catalog: 'каталог',
     github: 'исходный код'
@@ -81,7 +82,7 @@ const RU: StaticTextDefaultValue = {
     block: 'блочная'
   },
   footer: {
-    markdownTotal: 'Кол-во слов',
+    markdownTotal: 'Кол-во символов',
     scrollAuto: 'Автопрокрутка'
   }
 };


### PR DESCRIPTION
- added new key from b47a2cc
- fixed translation (was "word count", instead of correct "character count")