### PR TITLE
Use html3pdf instead of html2pdf.js to avoid canvas overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,10 @@
     "vite": "^5.2.10",
     "vite-plugin-dts": "^3.9.0",
     "vue": "^3.4.25"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "html3pdf@0.12.2": "patches/html3pdf@0.12.2.patch"
+    }
   }
 }

--- a/packages/rt/components/ExportPDF/ExportPDF.tsx
+++ b/packages/rt/components/ExportPDF/ExportPDF.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, CSSProperties, useRef, useState } from 'react';
 import { MdPreview, ModalToolbar, ExposePreviewParam } from 'md-editor-rt';
-import html2pdf from 'html2pdf.js';
+import html2pdf from 'html3pdf';
 import { prefix } from '@vavt/utils/src/static';
 import { CommomProps } from '../../common/props';
 

--- a/packages/rt/components/ExportPDF/ExportPDF.tsx
+++ b/packages/rt/components/ExportPDF/ExportPDF.tsx
@@ -23,6 +23,7 @@ interface Props extends CommomProps {
   onStart?: () => void;
   onSuccess?: () => void;
   onError?: (err: unknown) => void;
+  onProgress?: (progress: { val: number, state: string, n: number, stack: string[], ratio: number }) => void;
 }
 
 /**
@@ -56,6 +57,10 @@ const ExportPDF = (props: Props) => {
     setVisible(false);
   }, []);
 
+  const progressCallback = (progress: { val: number, state: string, n: number, stack: string[], ratio: number }) => {
+      props.onProgress && props.onProgress(progress);
+  };
+
   const onClick = useCallback(() => {
     // https://ekoopmans.github.io/html2pdf.js/
     const opt = {
@@ -63,9 +68,11 @@ const ExportPDF = (props: Props) => {
       filename: `${fileName}.pdf`,
       // https://html2canvas.hertzen.com/configuration
       html2canvas: {
-        scale: 2,
+        scale: 3,
         useCORS: true
       },
+      //Firefox max 9 pages, Chromium max 19 pages
+      pagesPerCanvas: 19,
       // 智能分页，防止图片被截断
       pagebreak: { mode: 'avoid-all' }
       // 支持文本中放链接，可点击跳转，默认true
@@ -85,7 +92,8 @@ const ExportPDF = (props: Props) => {
       })
       .finally(() => {
         previewRef.current?.rerender();
-      });
+      })
+      .listen(progressCallback);
   }, [fileName, props]);
 
   return (

--- a/packages/rt/components/ExportPDF/ExportPDF.tsx
+++ b/packages/rt/components/ExportPDF/ExportPDF.tsx
@@ -71,8 +71,8 @@ const ExportPDF = (props: Props) => {
         scale: 3,
         useCORS: true
       },
-      //Firefox max 9 pages, Chromium max 19 pages
-      pagesPerCanvas: 19,
+      // tested Firefox max 9 pages, Chromium max 19 pages
+      pagesPerCanvas: navigator.userAgent.includes('Chrome') ? 19 : 9,
       // 智能分页，防止图片被截断
       pagebreak: { mode: 'avoid-all' }
       // 支持文本中放链接，可点击跳转，默认true

--- a/packages/rt/components/ExportPDF/ExportPDF.tsx
+++ b/packages/rt/components/ExportPDF/ExportPDF.tsx
@@ -123,6 +123,7 @@ const ExportPDF = (props: Props) => {
           mdHeadingId={headingId}
           style={style}
           codeFoldable={false}
+          showCodeRowNumber={false}
         />
       </div>
       <div className={`${prefix}-form-item`}>

--- a/packages/rt/components/ExportPDF/README.md
+++ b/packages/rt/components/ExportPDF/README.md
@@ -45,3 +45,4 @@ export default () => {
 | onStart | `() => void` |  |  |
 | onSuccess | `() => void` |  |  |
 | onError | `(err: unknown) => void` |  |  |
+| onProgess | `(progress: { val: number, state: string, n: number, stack: string[], ratio: number }) => void`  |  |  |

--- a/packages/rt/components/ExportPDF/type.d.ts
+++ b/packages/rt/components/ExportPDF/type.d.ts
@@ -1,1 +1,1 @@
-declare module 'html2pdf.js';
+declare module 'html3pdf';

--- a/packages/rt/package.json
+++ b/packages/rt/package.json
@@ -38,6 +38,6 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "html2pdf.js": "^0.10.1"
+    "html3pdf": "^0.12.2"
   }
 }

--- a/packages/rt/scripts/build.ts
+++ b/packages/rt/scripts/build.ts
@@ -94,7 +94,7 @@ const resolvePath = (p: string) => path.resolve(__dirname, p);
             }
           },
           rollupOptions: {
-            external: ['react', 'md-editor-rt', 'html2pdf.js'],
+            external: ['react', 'md-editor-rt', 'html3pdf'],
             output: {
               chunkFileNames: `${t}/chunks/[name].${extnames[t]}`,
               assetFileNames: 'asset/[name][extname]'

--- a/packages/rt/styles/ExportPDF.scss
+++ b/packages/rt/styles/ExportPDF.scss
@@ -5,3 +5,7 @@
   margin-bottom: 20px;
   overflow: auto;
 }
+
+.export-pdf-content .md-editor-preview .md-editor-code pre code .md-editor-code-block {
+  text-wrap: wrap;
+}

--- a/packages/v3/components/ExportPDF/ExportPDF.tsx
+++ b/packages/v3/components/ExportPDF/ExportPDF.tsx
@@ -156,6 +156,7 @@ const ExportPDF = defineComponent({
               mdHeadingId={headingId}
               style={props.style}
               codeFoldable={false}
+              showCodeRowNumber={false}          
             />
           </div>
 

--- a/packages/v3/components/ExportPDF/ExportPDF.tsx
+++ b/packages/v3/components/ExportPDF/ExportPDF.tsx
@@ -2,7 +2,7 @@
 import { defineComponent, reactive, ref, CSSProperties } from 'vue';
 import type { PropType } from 'vue';
 import { MdPreview, ModalToolbar, ExposePreviewParam } from 'md-editor-v3';
-import html2pdf from 'html2pdf.js';
+import html2pdf from 'html3pdf';
 import { getSlot } from '@vavt/utils/src/vue-tsx';
 import { prefix } from '@vavt/utils/src/static';
 import { commomProps } from '../../common/props';

--- a/packages/v3/components/ExportPDF/ExportPDF.tsx
+++ b/packages/v3/components/ExportPDF/ExportPDF.tsx
@@ -97,8 +97,8 @@ const ExportPDF = defineComponent({
           scale: 3,
           useCORS: true
         },
-        //Firefox max 9 pages, Chromium max 19 pages
-        pagesPerCanvas: 19,
+        // tested Firefox max 9 pages, Chromium max 19 pages
+        pagesPerCanvas: navigator.userAgent.includes('Chrome') ? 19 : 9,
         // 智能分页，防止图片被截断
         pagebreak: { mode: 'avoid-all' }
         // 支持文本中放链接，可点击跳转，默认true

--- a/packages/v3/components/ExportPDF/ExportPDF.tsx
+++ b/packages/v3/components/ExportPDF/ExportPDF.tsx
@@ -2,7 +2,7 @@
 import { defineComponent, reactive, ref, CSSProperties } from 'vue';
 import type { PropType } from 'vue';
 import { MdPreview, ModalToolbar, ExposePreviewParam } from 'md-editor-v3';
-import html2pdf from 'html3pdf';
+import  html2pdf from 'html3pdf';
 import { getSlot } from '@vavt/utils/src/vue-tsx';
 import { prefix } from '@vavt/utils/src/static';
 import { commomProps } from '../../common/props';
@@ -57,9 +57,12 @@ const ExportPDF = defineComponent({
     onError: {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       type: Function as PropType<(err: unknown) => void>
+    },
+    onProgress: {
+      type: Function as PropType<(progress: { val: number, state: string, n: number, stack: string[], ratio: number }) => void>
     }
   },
-  emits: ['onStart', 'onSuccess', 'onError'],
+  emits: ['onStart', 'onSuccess', 'onError', 'onProgress'],
   setup(props, ctx) {
     const content = ref();
 
@@ -69,6 +72,13 @@ const ExportPDF = defineComponent({
       visible: false
     });
 
+    const progressCallback = (progress: { val: number, state: string, n: number, stack: string[], ratio: number }) => {
+      if (props.onProgress) {
+        props.onProgress(progress);
+      } else {
+        ctx.emit('onProgress', progress);
+      }
+    };
     /**
      * modal-toolbar组件不会再关闭时销毁子组件，这时需要区别预览扩展组件的标题ID生成方式和编辑器的标题ID生成方式
      *
@@ -84,9 +94,11 @@ const ExportPDF = defineComponent({
         filename: `${props.fileName}.pdf`,
         // https://html2canvas.hertzen.com/configuration
         html2canvas: {
-          scale: 2,
+          scale: 3,
           useCORS: true
         },
+        //Firefox max 9 pages, Chromium max 19 pages
+        pagesPerCanvas: 19,
         // 智能分页，防止图片被截断
         pagebreak: { mode: 'avoid-all' }
         // 支持文本中放链接，可点击跳转，默认true
@@ -106,7 +118,8 @@ const ExportPDF = defineComponent({
         })
         .finally(() => {
           previewRef.value?.rerender();
-        });
+        })
+        .listen(progressCallback);
     };
 
     return () => {

--- a/packages/v3/components/ExportPDF/README.md
+++ b/packages/v3/components/ExportPDF/README.md
@@ -8,7 +8,7 @@ Export content as a PDF file.
 <template>
   <MdEditor v-model="text" :toolbars="toolbars">
     <template #defToolbars>
-      <ExportPDF :modelValue="text" />
+      <ExportPDF :modelValue="text" @onProgress="handleProgress"/>
     </template>
   </MdEditor>
 </template>
@@ -26,6 +26,10 @@ import '@vavt/v3-extension/lib/asset/ExportPDF.css';
 
 const text = ref('# PDF');
 const toolbars = ['bold', 0, 'underline'];
+
+const handleProgress = (progress) => {
+  console.log(`Export progress: ${progress.ratio * 100}%`);
+}
 </script>
 ```
 
@@ -55,3 +59,4 @@ const toolbars = ['bold', 0, 'underline'];
 | onStart   | `() => void`             |     |             |
 | onSuccess | `() => void`             |     |             |
 | onError   | `(err: unknown) => void` |     |             |
+| onProgess | `(progress: { val: number, state: string, n: number, stack: string[], ratio: number }) => void`  |     |             |

--- a/packages/v3/components/ExportPDF/type.d.ts
+++ b/packages/v3/components/ExportPDF/type.d.ts
@@ -1,1 +1,1 @@
-declare module 'html2pdf.js';
+declare module 'html3pdf';

--- a/packages/v3/package.json
+++ b/packages/v3/package.json
@@ -35,6 +35,6 @@
     "vue-tsc": "^1.8.5"
   },
   "dependencies": {
-    "html2pdf.js": "^0.10.1"
+    "html3pdf": "^0.12.2"
   }
 }

--- a/packages/v3/scripts/build.ts
+++ b/packages/v3/scripts/build.ts
@@ -94,7 +94,7 @@ const resolvePath = (p: string) => path.resolve(__dirname, p);
             }
           },
           rollupOptions: {
-            external: ['vue', 'md-editor-v3', 'html2pdf.js'],
+            external: ['vue', 'md-editor-v3', 'html3pdf'],
             output: {
               chunkFileNames: `${t}/chunks/[name].${extnames[t]}`,
               assetFileNames: 'asset/[name][extname]'

--- a/packages/v3/styles/ExportPDF.scss
+++ b/packages/v3/styles/ExportPDF.scss
@@ -5,3 +5,7 @@
   margin-bottom: 20px;
   overflow: auto;
 }
+
+.export-pdf-content .md-editor-preview .md-editor-code pre code .md-editor-code-block {
+  text-wrap: wrap;
+}


### PR DESCRIPTION
- scale changed from 2 to 3 to output a clearer pdf
- change html2pdf.js to html3pdf to avoid canvas overflow
- apply a patch for html3pdf to patch the newest pull request which adds pagesPerCanvas option to speed up generate
- auto-detect userAgent to set a proper pagesPerCanvas option (only tested with Firefox127 - 9 , Chrome & Edge 126 - 19). So I set 9 for default but 19 for Chromium browsers
- add onProgress event to let users learn the progess of generation
- fix code not wrap in pdf and remove incorrect row numbers