### PR TITLE
Change markdownTotal label from 'کلمات' to 'حروف'

### DIFF
--- a/packages/common/src/locale/fa-IR.ts
+++ b/packages/common/src/locale/fa-IR.ts
@@ -86,7 +86,7 @@ const FA_IR: StaticTextDefaultValue = {
     block: 'بلوک'
   },
   footer: {
-    markdownTotal: 'تعداد کلمات',
+    markdownTotal: 'تعداد حروف',
     scrollAuto: 'اسکرول خودکار'
   }
 };


### PR DESCRIPTION
Change markdownTotal label from  words (کلمات) to letters (حروف)
it was miswritten in persian.